### PR TITLE
Use debian 10.11-slim for master, bump version

### DIFF
--- a/dockbot/data/master/master.docker
+++ b/dockbot/data/master/master.docker
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:10.11-slim
 MAINTAINER joseph@cauldrondevelopment.com
 
 # Install prerequisites

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name = 'dockbot',
-    version = '0.2.0',
+    version = '0.2.1',
     description =
     'A continuous integration system which uses Docker and Buildbot',
     long_description = open('README.md', 'rt').read(),


### PR DESCRIPTION
Debian:stable pulls debian 11, which does not have access to the required python2 packages.